### PR TITLE
mint-arena: Example for player model damage skins

### DIFF
--- a/baseq3/doom-damage-skin.pk3dir/models/players/doom/head_damage.skin
+++ b/baseq3/doom-damage-skin.pk3dir/models/players/doom/head_damage.skin
@@ -1,0 +1,3 @@
+h_helmet,models/players/doom/doom01,models/players/doom/doom02,models/players/doom/doom03,models/players/doom/doom04,models/players/doom/doom05,models/players/doom/doom06,models/players/doom/doom07,models/players/doom/doom08,models/players/doom/doom09,models/players/doom/doom10
+h_visor,models/players/doom/doom_f00
+tag_head,

--- a/baseq3/doom-damage-skin.pk3dir/models/players/doom/lower_damage.skin
+++ b/baseq3/doom-damage-skin.pk3dir/models/players/doom/lower_damage.skin
@@ -1,0 +1,2 @@
+l_legs,models/players/doom/doom01,models/players/doom/doom02,models/players/doom/doom03,models/players/doom/doom04,models/players/doom/doom05,models/players/doom/doom06,models/players/doom/doom07,models/players/doom/doom08,models/players/doom/doom09,models/players/doom/doom10
+tag_torso,

--- a/baseq3/doom-damage-skin.pk3dir/models/players/doom/upper_damage.skin
+++ b/baseq3/doom-damage-skin.pk3dir/models/players/doom/upper_damage.skin
@@ -1,0 +1,6 @@
+u_torso,models/players/doom/doom01,models/players/doom/doom02,models/players/doom/doom03,models/players/doom/doom04,models/players/doom/doom05,models/players/doom/doom06,models/players/doom/doom07,models/players/doom/doom08,models/players/doom/doom09,models/players/doom/doom10
+tag_head,
+tag_torso,
+tag_weapon,
+u_larm,models/players/doom/doom01,models/players/doom/doom02,models/players/doom/doom03,models/players/doom/doom04,models/players/doom/doom05,models/players/doom/doom06,models/players/doom/doom07,models/players/doom/doom08,models/players/doom/doom09,models/players/doom/doom10
+u_rarm,models/players/doom/doom01,models/players/doom/doom02,models/players/doom/doom03,models/players/doom/doom04,models/players/doom/doom05,models/players/doom/doom06,models/players/doom/doom07,models/players/doom/doom08,models/players/doom/doom09,models/players/doom/doom10

--- a/baseq3/doom-damage-skin.pk3dir/scripts/doom-damage-skin.shader
+++ b/baseq3/doom-damage-skin.pk3dir/scripts/doom-damage-skin.shader
@@ -1,0 +1,158 @@
+// Doom damage skins
+
+// Single shader damage skin (entity alpha)
+// mesh,models/players/doom/doom00
+
+models/players/doom/doom00
+{
+	{
+		map models/players/doom/doom.tga
+		rgbGen lightingDiffuse
+	}
+	{
+		map models/players/doom/doom_statue.tga
+		alphaGen entity
+		blendFunc blend
+	}
+}
+
+models/players/doom/doom_f00
+{
+	{
+		map models/players/doom/doom_f.tga
+		rgbGen lightingDiffuse
+	}
+	{
+		map models/players/doom/doom_f_statue.tga
+		alphaGen entity
+		blendFunc blend
+	}
+}
+
+// Multi-shader damage skin:
+// mesh,models/players/doom/doom01,models/players/doom/doom02,models/players/doom/doom03,models/players/doom/doom04,models/players/doom/doom05,models/players/doom/doom06,models/players/doom/doom07,models/players/doom/doom08,models/players/doom/doom09,models/players/doom/doom10
+
+// 91+ health
+models/players/doom/doom01
+{
+	{
+		map models/players/doom/doom.tga
+		rgbGen lightingDiffuse
+	}
+}
+
+// 81 - 90 health
+models/players/doom/doom02
+{
+	{
+		map models/players/doom/doom.tga
+		rgbGen lightingDiffuse
+	}
+	{
+		map models/players/doom/red.tga
+		alphaGen const 0.3
+		blendFunc blend
+	}
+}
+
+// 71 - 80 health
+models/players/doom/doom03
+{
+	{
+		map models/players/doom/doom.tga
+		rgbGen lightingDiffuse
+	}
+	{
+		map models/players/doom/red.tga
+		alphaGen const 0.4
+		blendFunc blend
+	}
+}
+
+// 61 - 70 health
+models/players/doom/doom04
+{
+	{
+		map models/players/doom/doom.tga
+		rgbGen lightingDiffuse
+	}
+	{
+		map models/players/doom/red.tga
+		alphaGen const 0.6
+		blendFunc blend
+	}
+}
+
+// 51 - 60 health
+models/players/doom/doom05
+{
+	{
+		map models/players/doom/doom.tga
+		rgbGen lightingDiffuse
+	}
+	{
+		map models/players/doom/red.tga
+		alphaGen const 0.8
+		blendFunc blend
+	}
+}
+
+// 41 - 50 health
+models/players/doom/doom06
+{
+	{
+		map models/players/doom/red.tga
+		rgbGen lightingDiffuse
+	}
+}
+
+// 31 - 40 health
+models/players/doom/doom07
+{
+	{
+		map models/players/doom/red.tga
+		rgbGen lightingDiffuse
+	}
+	{
+		map models/players/doom/doom_statue.tga
+		alphaGen const 0.25
+		blendFunc blend
+	}
+}
+
+// 21 - 30 health
+models/players/doom/doom08
+{
+	{
+		map models/players/doom/red.tga
+		rgbGen lightingDiffuse
+	}
+	{
+		map models/players/doom/doom_statue.tga
+		alphaGen const 0.5
+		blendFunc blend
+	}
+}
+
+// 11 - 20 health
+models/players/doom/doom09
+{
+	{
+		map models/players/doom/red.tga
+		rgbGen lightingDiffuse
+	}
+	{
+		map models/players/doom/doom_statue.tga
+		alphaGen const 0.75
+		blendFunc blend
+	}
+}
+
+// 0 - 10 health
+models/players/doom/doom10
+{
+	{
+		map models/players/doom/doom_statue.tga
+		rgbGen lightingDiffuse
+	}
+}

--- a/code/cgame/cg_ents.c
+++ b/code/cgame/cg_ents.c
@@ -1120,11 +1120,11 @@ static void CG_TeamBase( centity_t *cent ) {
 
 		if ( cent->currentState.modelindex == TEAM_RED ) {
 			model.hModel = cgs.media.harvesterModel;
-			model.customSkin = CG_AddSkinToFrame( &cgs.media.harvesterRedSkin );
+			model.customSkin = CG_AddSkinToFrame( &cgs.media.harvesterRedSkin, &cent->currentState );
 		}
 		else if ( cent->currentState.modelindex == TEAM_BLUE ) {
 			model.hModel = cgs.media.harvesterModel;
-			model.customSkin = CG_AddSkinToFrame( &cgs.media.harvesterBlueSkin );
+			model.customSkin = CG_AddSkinToFrame( &cgs.media.harvesterBlueSkin, &cent->currentState );
 		}
 		else {
 			model.hModel = cgs.media.harvesterNeutralModel;

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -203,9 +203,15 @@ typedef struct {
 
 // skin surfaces array shouldn't be dynamically allocated because players reuse the same skin structure when changing models
 #define MAX_CG_SKIN_SURFACES 100
+#define MAX_CG_SKIN_SURFACE_SHADERS 10
 typedef struct {
-	int numSurfaces;
-	qhandle_t surfaces[MAX_CG_SKIN_SURFACES];
+	qhandle_t surfaces[MAX_CG_SKIN_SURFACE_SHADERS]; // allocated skin surfaces (mesh name + shader)
+	int numShaders;
+} cgSkinMesh_t;
+
+typedef struct {
+	int numMeshes;
+	cgSkinMesh_t meshes[MAX_CG_SKIN_SURFACES];
 } cgSkin_t;
 
 //=================================================
@@ -1713,7 +1719,7 @@ int CG_Text_Height( const char *text, float scale, int limit );
 void CG_Player( centity_t *cent );
 void CG_ResetPlayerEntity( centity_t *cent );
 void CG_AddRefEntityWithPowerups( refEntity_t *ent, entityState_t *state );
-qhandle_t CG_AddSkinToFrame( const cgSkin_t *skin );
+qhandle_t CG_AddSkinToFrame( const cgSkin_t *skin, entityState_t *state );
 qboolean CG_RegisterSkin( const char *name, cgSkin_t *skin, qboolean append );
 void CG_NewPlayerInfo( int playerNum );
 sfxHandle_t	CG_CustomSound( int playerNum, const char *soundName );

--- a/code/game/bg_misc.c
+++ b/code/game/bg_misc.c
@@ -909,6 +909,7 @@ vmNetField_t	bg_entityStateFields[] =
 { NETF(origin[0]), 0 },
 { NETF(origin[1]), 0 },
 { NETF(origin[2]), 0 },
+{ NETF(skinFraction), 0 },
 { NETF(contents), 32 },
 { NETF(collisionType), 16 },
 { NETF(mins[0]), 0 },
@@ -1739,6 +1740,14 @@ void BG_PlayerStateToEntityState( playerState_t *ps, entityState_t *s, qboolean 
 		SnapVector( s->mins );
 		SnapVector( s->maxs );
 	}
+
+	if ( ps->stats[STAT_HEALTH] <= 0 ) {
+		s->skinFraction = 1.0f;
+	} else if ( ps->stats[STAT_HEALTH] >= ps->stats[STAT_MAX_HEALTH] ) {
+		s->skinFraction = 0.0f;
+	} else {
+		s->skinFraction = 1.0f - ( (float)ps->stats[STAT_HEALTH] / (float)ps->stats[STAT_MAX_HEALTH] );
+	}
 }
 
 /*
@@ -1827,6 +1836,14 @@ void BG_PlayerStateToEntityStateExtraPolate( playerState_t *ps, entityState_t *s
 	if ( snap ) {
 		SnapVector( s->mins );
 		SnapVector( s->maxs );
+	}
+
+	if ( ps->stats[STAT_HEALTH] <= 0 ) {
+		s->skinFraction = 1.0f;
+	} else if ( ps->stats[STAT_HEALTH] >= ps->stats[STAT_MAX_HEALTH] ) {
+		s->skinFraction = 0.0f;
+	} else {
+		s->skinFraction = 1.0f - ( (float)ps->stats[STAT_HEALTH] / (float)ps->stats[STAT_MAX_HEALTH] );
 	}
 }
 

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -50,7 +50,7 @@ Suite 120, Rockville, Maryland 20850 USA.
 // because games can change separately from the main system protocol, we need a
 // second protocol that must match between game and cgame
 
-#define	GAME_PROTOCOL		MODDIR "-4"
+#define	GAME_PROTOCOL		MODDIR "damageskins-4"
 
 // used for switching fs_game
 #ifndef BASEQ3
@@ -276,6 +276,7 @@ typedef struct entityState_s {
 	int		legsAnim;		// mask off ANIM_TOGGLEBIT
 	int		torsoAnim;		// mask off ANIM_TOGGLEBIT
 	int		tokens;			// harvester skulls
+	float	skinFraction;	// 0 = full health, 1 = dead
 } entityState_t;
 
 

--- a/code/q3_ui/ui_players.c
+++ b/code/q3_ui/ui_players.c
@@ -821,7 +821,7 @@ void UI_DrawPlayer( float x, float y, float w, float h, uiPlayerInfo_t *pi, int 
 	// add the legs
 	//
 	legs.hModel = pi->legsModel;
-	legs.customSkin = CG_AddSkinToFrame( &pi->modelSkin );
+	legs.customSkin = CG_AddSkinToFrame( &pi->modelSkin, NULL );
 
 	VectorCopy( origin, legs.origin );
 

--- a/code/ui/ui_players.c
+++ b/code/ui/ui_players.c
@@ -826,7 +826,7 @@ void UI_DrawPlayer( float x, float y, float w, float h, uiPlayerInfo_t *pi, int 
 	// add the legs
 	//
 	legs.hModel = pi->legsModel;
-	legs.customSkin = CG_AddSkinToFrame( &pi->modelSkin );
+	legs.customSkin = CG_AddSkinToFrame( &pi->modelSkin, NULL );
 
 	VectorCopy( origin, legs.origin );
 


### PR DESCRIPTION
Load up to 10 shaders for each mesh from .skin files. Use first shader
at full health and later shaders as health decreases. If there are only
two shaders, then first is for health 51+ and second is for 0 to 50.

Put baseq3/doom-damage-skin.pk3dir in your baseq3 directory, use
'model doom/damage' and cg_forceModel 1 so bots use it too.

Based on unused code I wrote for Turtle Arena (removed in TA 0.7).